### PR TITLE
添加 alist http url类型的 302重定向方案

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -42,6 +42,20 @@ ClientFilter:                               # 客户端过滤器
     - Infuse
 
 # 302重定向相关配置
+AlistHTTPStrm:                              # AlistHTTPStrm 相关配置（Strm文件内容是Alist上文件的alist url，目前仅支持适配Alist V3）
+  Enable: True                              # 是否启用AlistStrm重定向
+  List:                                     # Alist服务关配置列表
+    - ADDR: http://192.168.1.100:5244       # Alist服务器地址（MediaWarp可以正常访问到就可以）
+      Username: admin                       # Alist服务器账号
+      Password: adminadmin                  # Alist服务器密码
+      PrefixList:                           # EmbyServer中Strm文件的前缀（符合该前缀的Strm文件都会路由到该规则下）
+        - /media/strm/MyAlist               # 同一个Alist可以有多个前缀规则
+        - /mnt/cd2/strm
+    - ADDR: https://xiaoya.com              # 可以填写多个配置
+      Username: admin
+      Password: adminadmin
+      PrefixList: 
+        - /media/strm
 
 HTTPStrm: 
   Enable: True                              # 是否开启HttpStrm重定向

--- a/constants/strm.go
+++ b/constants/strm.go
@@ -5,5 +5,6 @@ type StrmFileType string // Strm 文件类型
 var (
 	HTTPStrm    StrmFileType = "HTTPStrm"
 	AlistStrm   StrmFileType = "AlistStrm"
+	AlistHTTPStrm   StrmFileType = "AlistHTTPStrm"
 	UnknownStrm StrmFileType = "UnknownStrm"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,15 +21,16 @@ var (
 		Arch:       runtime.GOARCH,
 	}
 
-	Port         int                 // MediaWarp开放端口
-	MediaServer  MediaServerSetting  // 上游媒体服务器设置
-	Cache        CacheSetting        // 缓存相关设置
-	Logger       LoggerSetting       // 日志设置
-	Web          WebSetting          // Web服务器设置
-	ClientFilter ClientFilterSetting // 客户端过滤设置
-	HTTPStrm     HTTPStrmSetting     // HTTPSTRM设置
-	AlistStrm    AlistStrmSetting    // AlistStrm设置
-	Subtitle     SubtitleSetting     // 字幕设置
+	Port          int                 // MediaWarp开放端口
+	MediaServer   MediaServerSetting  // 上游媒体服务器设置
+	Cache         CacheSetting        // 缓存相关设置
+	Logger        LoggerSetting       // 日志设置
+	Web           WebSetting          // Web服务器设置
+	ClientFilter  ClientFilterSetting // 客户端过滤设置
+	HTTPStrm      HTTPStrmSetting     // HTTPSTRM设置
+	AlistHTTPStrm AlistStrmSetting    // HTTPSTRM设置
+	AlistStrm     AlistStrmSetting    // AlistStrm设置
+	Subtitle      SubtitleSetting     // 字幕设置
 )
 
 // 获取版本信息
@@ -131,6 +132,9 @@ func loadConfig() {
 	}
 	if err := viper.UnmarshalKey("ClientFilter", &ClientFilter); err != nil {
 		panic(fmt.Errorf("ClientFilterSetting  解析失败, %v", err))
+	}
+	if err := viper.UnmarshalKey("AlistHTTPStrm", &AlistHTTPStrm); err != nil {
+		panic(fmt.Errorf("AlistHTTPStrm  解析失败, %v", err))
 	}
 	if err := viper.UnmarshalKey("HTTPStrm", &HTTPStrm); err != nil {
 		panic(fmt.Errorf("HTTPStrmSetting  解析失败, %v", err))

--- a/internal/handler/emby.go
+++ b/internal/handler/emby.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"path"
 	"reflect"
 	"strconv"
@@ -103,6 +104,16 @@ func (embyServerHandler *EmbyServerHandler) responseModifyCreater(modifyResponse
 //
 // 返回 Strm 文件类型和一个可选配置
 func (embyServerHandler *EmbyServerHandler) RecgonizeStrmFileType(strmFilePath string) (constants.StrmFileType, any) {
+	if config.AlistHTTPStrm.Enable {
+		for _, alistHTTPStrmConfig := range config.AlistHTTPStrm.List {
+			for _, prefix := range alistHTTPStrmConfig.PrefixList {
+				if strings.HasPrefix(strmFilePath, prefix) {
+					logging.Debug(strmFilePath + " 成功匹配路径：" + prefix + "，Strm 类型：" + string(constants.AlistHTTPStrm) + "，AlistServer 地址：" + alistHTTPStrmConfig.ADDR)
+					return constants.AlistHTTPStrm, alistHTTPStrmConfig.ADDR
+				}
+			}
+		}
+	}
 	if config.HTTPStrm.Enable {
 		for _, prefix := range config.HTTPStrm.PrefixList {
 			if strings.HasPrefix(strmFilePath, prefix) {
@@ -153,6 +164,8 @@ func (embyServerHandler *EmbyServerHandler) ModifyPlaybackInfo(rw *http.Response
 		item := itemResponse.Items[0]
 		strmFileType, opt := embyServerHandler.RecgonizeStrmFileType(*item.Path)
 		switch strmFileType {
+		case constants.AlistHTTPStrm:
+			fallthrough
 		case constants.HTTPStrm: // HTTPStrm 设置支持直链播放并且支持转码
 			*playbackInfoResponse.MediaSources[index].SupportsDirectPlay = true
 			*playbackInfoResponse.MediaSources[index].SupportsDirectStream = true
@@ -256,6 +269,26 @@ func (embyServerHandler *EmbyServerHandler) VideosHandler(ctx *gin.Context) {
 	for _, mediasource := range item.MediaSources {
 		if *mediasource.ID == mediaSourceID { // EmbyServer >= 4.9 返回的ID带有前缀mediasource_
 			switch strmFileType {
+			case constants.AlistHTTPStrm:
+				parsed, err := url.Parse(*mediasource.Path)
+				if err != nil {
+					logging.Error(err)
+					return
+				}
+				path := strings.ReplaceAll(parsed.Path, "/d", "")
+				path = strings.ReplaceAll(path, "//", "/")
+				alistServerAddr := opt.(string)
+				alistServer := service.GetAlistServer(alistServerAddr)
+				logging.Info("Path: ", path)
+				fsGetData, err := alistServer.FsGet(path)
+				if err != nil {
+					logging.Warning("请求 FsGet 失败：", err)
+					return
+				}
+				logging.Info("AlistHTTPStrm 重定向至：", fsGetData.RawURL)
+				ctx.Redirect(http.StatusFound, fsGetData.RawURL)
+				return
+
 			case constants.HTTPStrm:
 				if *mediasource.Protocol == emby.HTTP {
 					logging.Info("HTTPStrm 重定向至：", *mediasource.Path)

--- a/internal/service/alist.go
+++ b/internal/service/alist.go
@@ -17,6 +17,13 @@ func init() {
 		for _, alist := range config.AlistStrm.List {
 			registerAlistServer(alist.ADDR, alist.Username, alist.Password)
 		}
+
+	}
+	if config.AlistHTTPStrm.Enable {
+
+		for _, alist := range config.AlistHTTPStrm.List {
+			registerAlistServer(alist.ADDR, alist.Username, alist.Password)
+		}
 	}
 }
 


### PR DESCRIPTION
支持 strm文件内写入的HTTP连接是alist URL 时的重定向方案
编写配置类似 AlistStrm

```yaml
AlistHTTPStrm:                              # AlistHTTPStrm 相关配置（Strm文件内容是Alist上文件的alist url，目前仅支持适配Alist V3）
  Enable: True                              # 是否启用AlistStrm重定向
  List:                                     # Alist服务关配置列表
    - ADDR: http://192.168.1.100:5244       # Alist服务器地址（MediaWarp可以正常访问到就可以）
      Username: admin                       # Alist服务器账号
      Password: adminadmin                  # Alist服务器密码
      PrefixList:                           # EmbyServer中Strm文件的前缀（符合该前缀的Strm文件都会路由到该规则下）
        - /media/strm/MyAlist               # 同一个Alist可以有多个前缀规则
        - /mnt/cd2/strm
    - ADDR: https://xiaoya.com              # 可以填写多个配置
      Username: admin
      Password: adminadmin
      PrefixList: 
        - /media/strm
```
当检测到符合条件的strm时，会解析alist url 的path，然后调用alist接口获取真实的下载链接

## 解决的问题
1. 当strm内写入的是内网链接时，可以使用该工具重定向，无需客户端链接到内网，无需修改strm文件
2. 原emby服务不需要进行适配，可以直接使用，内网下使用原emby，外网使用重定向方案
