### PR TITLE
jellyfin router regexp 

### DIFF
--- a/constants/regexp.go
+++ b/constants/regexp.go
@@ -44,9 +44,9 @@ type JellyfinRegexps struct {
 
 var JellyfinRegexp = &JellyfinRegexps{
 	Router: JellyfinRouterRegexps{
-		VideosHandler:      regexp.MustCompile(`(/emby)?/Videos/\w+/(stream|original)(\.\w+)?$`), // /Videos/813a630bcf9c3f693a2ec8c498f868d2/stream /Videos/205953b114bb8c9dc2c7ba7e44b8024c/stream.mp4
-		ModifyIndex:        regexp.MustCompile(`^(/emby)?/web/$`),
-		ModifyPlaybackInfo: regexp.MustCompile(`^(/emby)?/Items/\w+/PlaybackInfo$`),
-		ModifySubtitles:    regexp.MustCompile(`(/emby)?/Videos/\d+/\w+/subtitles$`),
+		VideosHandler:      regexp.MustCompile(`(?i)^(/emby)?/Videos/\w+/(stream|original)(\.\w+)?$`), // /Videos/813a630bcf9c3f693a2ec8c498f868d2/stream /Videos/205953b114bb8c9dc2c7ba7e44b8024c/stream.mp4
+		ModifyIndex:        regexp.MustCompile(`(?i)^(/emby)?/web/$`),
+		ModifyPlaybackInfo: regexp.MustCompile(`(?i)^(/emby)?/Items/\w+/PlaybackInfo$`),
+		ModifySubtitles:    regexp.MustCompile(`(?i)^(/emby)?/Videos/\d+/\w+/subtitles$`),
 	},
 }

--- a/constants/regexp.go
+++ b/constants/regexp.go
@@ -44,9 +44,9 @@ type JellyfinRegexps struct {
 
 var JellyfinRegexp = &JellyfinRegexps{
 	Router: JellyfinRouterRegexps{
-		VideosHandler:      regexp.MustCompile(`/Videos/\w+/(stream|original)(\.\w+)?$`), // /Videos/813a630bcf9c3f693a2ec8c498f868d2/stream /Videos/205953b114bb8c9dc2c7ba7e44b8024c/stream.mp4
-		ModifyIndex:        regexp.MustCompile(`^/web/$`),
-		ModifyPlaybackInfo: regexp.MustCompile(`^/Items/\w+/PlaybackInfo$`),
-		ModifySubtitles:    regexp.MustCompile(`/Videos/\d+/\w+/subtitles$`),
+		VideosHandler:      regexp.MustCompile(`(/emby)?/Videos/\w+/(stream|original)(\.\w+)?$`), // /Videos/813a630bcf9c3f693a2ec8c498f868d2/stream /Videos/205953b114bb8c9dc2c7ba7e44b8024c/stream.mp4
+		ModifyIndex:        regexp.MustCompile(`^(/emby)?/web/$`),
+		ModifyPlaybackInfo: regexp.MustCompile(`^(/emby)?/Items/\w+/PlaybackInfo$`),
+		ModifySubtitles:    regexp.MustCompile(`(/emby)?/Videos/\d+/\w+/subtitles$`),
 	},
 }


### PR DESCRIPTION
增加 (?i)^(/emby)? 解决 senplayer使用emby api调用的问题

使senplayer也能成功播放