### PR TITLE
🐛 修复 Emby 章节信息和缩略图显示问题

### DIFF
--- a/constants/regexp.go
+++ b/constants/regexp.go
@@ -38,8 +38,9 @@ var EmbyRegexp = &EmbyRegexps{
 	},
 	// /emby/Items/6/Images/Primary
 	// /emby/Items/13/Images/Primary
+	// /emby/Items/123/Images/Chapter/0
 	Cache: CacheRegexps{
-		Image:    regexp.MustCompile(`(?i)^(/emby)?/Items/\d+/Images`),
+		Image:    regexp.MustCompile(`(?i)^(/emby)?/Items/\d+/Images(/.*)?$`),
 		Subtitle: regexp.MustCompile(`(?i)/Videos/(.*)/Subtitles/(.*)/Stream\.(ass|ssa|srt|)?$`),
 	},
 }
@@ -65,7 +66,8 @@ var JellyfinRegexp = &JellyfinRegexps{
 	Cache: CacheRegexps{
 		// /Items/19ba9e43f0db12e2eea4294609ec1a0c/Images/Primary
 		// /Items/20524938b33d516922ccea207555315b/Images/Backdrop/0
-		Image: regexp.MustCompile(`(?i)/Items/\w+/Images`),
+		// /Items/abc123/Images/Chapter/0
+		Image: regexp.MustCompile(`(?i)/Items/\w+/Images(/.*)?$`),
 
 		// /Videos/6c252d46-952c-5b0d-5f0e-f6e3036c0a39/6c252d46952c5b0d5f0ef6e3036c0a39/Subtitles/2/0/Stream.ass
 		Subtitle: regexp.MustCompile(`(?i)/Videos/(.*)/Subtitles/(.*)/Stream\.(ass|ssa|srt|)?$`),

--- a/internal/middleware/cache.go
+++ b/internal/middleware/cache.go
@@ -67,6 +67,7 @@ var CacheKeyIgnoreQuery = []string{
 
 	// Emby
 	"playsessionid",
+	"tag", // 忽略 ImageTag 参数，防止 Emby 重启后缓存失效
 }
 
 // 计算Key时忽略的请求头

--- a/internal/service/emby/schema.go
+++ b/internal/service/emby/schema.go
@@ -10,6 +10,7 @@ type PlaybackInfoResponse struct {
 	ErrorCode     *PlaybackErrorCode `json:"ErrorCode,omitempty"`
 	MediaSources  []MediaSourceInfo  `json:"MediaSources,omitempty"`
 	PlaySessionID *string            `json:"PlaySessionId,omitempty"`
+	Chapters      []ChapterInfo      `json:"Chapters,omitempty"`
 }
 
 // PlaybackErrorCode
@@ -212,6 +213,7 @@ type MediaSourceInfo struct {
 	AnalyzeDurationMS          *int64                    `json:"AnalyzeDurationMs,omitempty"`
 	Bitrate                    *int64                    `json:"Bitrate,omitempty"`
 	BufferMS                   *int64                    `json:"BufferMs,omitempty"`
+	Chapters                   []ChapterInfo             `json:"Chapters,omitempty"`
 	Container                  *string                   `json:"Container,omitempty"` // AlistStrm 显示 strm，普通视频和 HTTPStrm
 	ContainerStartTimeTicks    *int64                    `json:"ContainerStartTimeTicks,omitempty"`
 	DefaultAudioStreamIndex    *int64                    `json:"DefaultAudioStreamIndex,omitempty"`


### PR DESCRIPTION
## 问题描述

Emby 客户端播放包含章节的视频时存在以下问题：
1. 章节信息无法显示
2. 章节缩略图缺失
3. Emby 服务器重启后缩略图和章节信息消失

## 根本原因

1. **图片缓存正则不匹配**：无法匹配章节图片路径 `/Items/123/Images/Chapter/0`
2. **Schema 缺少字段**：`PlaybackInfoResponse` 和 `MediaSourceInfo` 缺少 `Chapters` 字段
3. **缓存键包含 ImageTag**：Emby 重启时 ImageTag 变化导致缓存失效

## 解决方案

### 1. 修复图片缓存正则表达式
**文件**: `constants/regexp.go`
```diff
- Image: regexp.MustCompile(`(?i)^(/emby)?/Items/\d+/Images`)
+ Image: regexp.MustCompile(`(?i)^(/emby)?/Items/\d+/Images(/.*)?$`)
```

### 2. 添加 Chapters 字段
**文件**: `internal/service/emby/schema.go`
```diff
 type PlaybackInfoResponse struct {
+    Chapters []ChapterInfo `json:"Chapters,omitempty"`
 }
 
 type MediaSourceInfo struct {
+    Chapters []ChapterInfo `json:"Chapters,omitempty"`
 }
```

### 3. 忽略 ImageTag 缓存参数
**文件**: `internal/middleware/cache.go`
```diff
 var CacheKeyIgnoreQuery = []string{
     "playsessionid",
+    "tag", // 忽略 ImageTag 参数，防止 Emby 重启后缓存失效
 }
```

## 测试验证

- ✅ 播放包含章节的视频，章节信息正常显示
- ✅ 章节缩略图正常显示
- ✅ Emby 服务器重启后章节功能仍然正常
- ✅ 缓存命中率提升，性能改进

## 改动统计

- 3 个文件
- 新增 7 行，修改 2 行
- 向后兼容，无破坏性变更

## Docker 镜像

已构建并测试的 Docker 镜像：
```bash
docker pull algebla/mediawarp:latest
```

---

感谢审阅！