### PR TITLE
feat: 避免非播放动作导致的 302 链接获取，以及兼容一些播放器会同时发起多个播放请求

### DIFF
--- a/internal/handler/jellyfin.go
+++ b/internal/handler/jellyfin.go
@@ -20,16 +20,18 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
 
 // Jellyfin 服务器处理器
 type JellyfinHandler struct {
-	server          *jellyfin.Jellyfin     // Jellyfin 服务器
-	routerRules     []RegexpRouteRule      // 正则路由规则
-	proxy           *httputil.ReverseProxy // 反向代理
-	httpStrmHandler StrmHandlerFunc
+	server            *jellyfin.Jellyfin     // Jellyfin 服务器
+	routerRules       []RegexpRouteRule      // 正则路由规则
+	proxy             *httputil.ReverseProxy // 反向代理
+	httpStrmHandler   StrmHandlerFunc
+	playbackInfoMutex sync.Map // 视频流处理并发控制，确保同一个 item ID 的重定向请求串行化，避免重复获取缓存
 }
 
 func NewJellyfinHander(addr string, apiKey string) (*JellyfinHandler, error) {
@@ -101,6 +103,16 @@ func (JellyfinHandler) GetSubtitleCacheRegexp() *regexp.Regexp {
 // /Items/:itemId
 // 强制将 HTTPStrm 设置为支持直链播放和转码、AlistStrm 设置为支持直链播放并且禁止转码
 func (jellyfinHandler *JellyfinHandler) ModifyPlaybackInfo(rw *http.Response) error {
+	// 检查 IsPlayback 参数，如果为 false 则不做修改直接返回
+	// 从响应的请求中获取参数，因为响应对象包含原始请求
+	// 使用不区分大小写的方式获取查询参数
+	isPlayback := getQueryValueCaseInsensitive(rw.Request.URL.Query(), "IsPlayback")
+	logging.Debugf("IsPlayback 参数值: '%s' (请求 URL: %s)", isPlayback, rw.Request.URL.String())
+	if strings.ToLower(isPlayback) == "false" {
+		logging.Debug("IsPlayback=false，跳过 PlaybackInfo 修改")
+		return nil
+	}
+
 	defer rw.Body.Close()
 	data, err := io.ReadAll(rw.Body)
 	if err != nil {
@@ -207,6 +219,30 @@ func (jellyfinHandler *JellyfinHandler) VideosHandler(ctx *gin.Context) {
 		return
 	}
 
+	// 从 URL 中提取 item ID（例如：/Videos/813a630bcf9c3f693a2ec8c498f868d2/stream 中的 813a630bcf9c3f693a2ec8c498f868d2）
+	var itemID string
+	path := ctx.Request.URL.Path
+	if matches := constants.JellyfinRegexp.Router.VideosHandler.FindStringSubmatch(path); len(matches) > 0 {
+		parts := strings.Split(path, "/")
+		for i, part := range parts {
+			if part == "Videos" && i+1 < len(parts) {
+				itemID = parts[i+1]
+				break
+			}
+		}
+	}
+
+	// 并发控制：确保同一个 item ID 只有一个任务在运行
+	// 将整个处理流程放在锁内，避免重复查询和重复获取重定向 URL
+	var mu *sync.Mutex
+	if itemID != "" {
+		mutex, _ := jellyfinHandler.playbackInfoMutex.LoadOrStore(itemID, &sync.Mutex{})
+		mu = mutex.(*sync.Mutex)
+		mu.Lock()
+		defer mu.Unlock()
+		logging.Debugf("开始处理 item %s 的 VideosHandler 请求", itemID)
+	}
+
 	mediaSourceID := ctx.Query("mediasourceid")
 	logging.Debugf("请求 ItemsServiceQueryItem：%s", mediaSourceID)
 	itemResponse, err := jellyfinHandler.server.ItemsServiceQueryItem(mediaSourceID, 1, "Path,MediaSources") // 查询 item 需要去除前缀仅保留数字部分
@@ -230,6 +266,7 @@ func (jellyfinHandler *JellyfinHandler) VideosHandler(ctx *gin.Context) {
 			switch strmFileType {
 			case constants.HTTPStrm:
 				if *mediasource.Protocol == jellyfin.HTTP {
+					// httpStrmHandler 内部有缓存机制，锁确保串行化访问
 					ctx.Redirect(http.StatusFound, jellyfinHandler.httpStrmHandler(*mediasource.Path, ctx.Request.UserAgent()))
 					return
 				}

--- a/internal/handler/utils.go
+++ b/internal/handler/utils.go
@@ -40,6 +40,22 @@ func responseModifyCreater(proxy *httputil.ReverseProxy, modifyResponseFN func(r
 	}
 }
 
+// 不区分大小写地获取查询参数值
+//
+// 从 url.Values 中查找指定键名的值，忽略大小写
+func getQueryValueCaseInsensitive(query url.Values, key string) string {
+	keyLower := strings.ToLower(key)
+	for k, v := range query {
+		if strings.ToLower(k) == keyLower {
+			if len(v) > 0 {
+				return v[0]
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
 // 根据 Strm 文件路径识别 Strm 文件类型
 //
 // 返回 Strm 文件类型和一个可选配置


### PR DESCRIPTION
PlaybackInfo 接口通常会带一个 IsPlayback 参数，Emby 官方客户端的实现中，进入详情页触发的 PlaybackInfo 请求的 IsPlayback=false，而真正播放的时候的 PlaybackInfo 调用 IsPlayback=true，所以可以根据这个特征做过滤

另外观察到一些播放器会发起多个 IsPlayback=true 的请求，同时触发多个 stream 接口调用，所以在 stream 接口加了锁避免同一个 item 多次触发 302 链接获取

fixed: #68