### PR TITLE
fix: 优化 VideosHandler 中的 mutex 管理，防止内存泄漏

### DIFF
--- a/internal/handler/emby.go
+++ b/internal/handler/emby.go
@@ -266,7 +266,11 @@ func (embyServerHandler *EmbyServerHandler) VideosHandler(ctx *gin.Context) {
 		mutex, _ := embyServerHandler.playbackInfoMutex.LoadOrStore(itemID, &sync.Mutex{})
 		mu = mutex.(*sync.Mutex)
 		mu.Lock()
-		defer mu.Unlock()
+		defer func() {
+			mu.Unlock()
+			// 清理mutex，防止内存泄漏
+			embyServerHandler.playbackInfoMutex.Delete(itemID)
+		}()
 		logging.Debugf("开始处理 item %s 的 VideosHandler 请求", itemID)
 	}
 

--- a/internal/handler/jellyfin.go
+++ b/internal/handler/jellyfin.go
@@ -239,7 +239,11 @@ func (jellyfinHandler *JellyfinHandler) VideosHandler(ctx *gin.Context) {
 		mutex, _ := jellyfinHandler.playbackInfoMutex.LoadOrStore(itemID, &sync.Mutex{})
 		mu = mutex.(*sync.Mutex)
 		mu.Lock()
-		defer mu.Unlock()
+		defer func() {
+			mu.Unlock()
+			// 清理mutex，防止内存泄漏
+			jellyfinHandler.playbackInfoMutex.Delete(itemID)
+		}()
 		logging.Debugf("开始处理 item %s 的 VideosHandler 请求", itemID)
 	}
 


### PR DESCRIPTION
在 Emby 和 Jellyfin 的 VideosHandler 中，修改了 mutex 的解锁逻辑，确保在处理完成后清理 mutex，避免内存泄漏问题。