### PR TITLE
Fix .strm file path handling in Jellyfin/Emby handlers

### DIFF
--- a/internal/handler/emby.go
+++ b/internal/handler/emby.go
@@ -243,15 +243,16 @@ func (handler *EmbyHandler) VideosHandler(ctx *gin.Context) {
 		logging.Debugf("mediasource.ID: %s ; mediaSourceID: %s ; mediaSourceID_without_prefix: %s", *mediasource.ID, mediaSourceID, mediaSourceID_without_prefix)
 		// EmbyServer >= 4.9 返回的ID带有前缀mediasource_
 		if strings.Replace(*mediasource.ID, "mediasource_", "", 1) == mediaSourceID_without_prefix {
+			strmContent := readStrmContent(*mediasource.Path)
 			switch strmFileType {
 			case constants.HTTPStrm:
 				if *mediasource.Protocol == emby.HTTP {
-					ctx.Redirect(http.StatusFound, handler.httpStrmHandler(*mediasource.Path, ctx.Request.UserAgent()))
+					ctx.Redirect(http.StatusFound, handler.httpStrmHandler(strmContent, ctx.Request.UserAgent()))
 					return
 				}
 
 			case constants.AlistStrm: // 无需判断 *mediasource.Container 是否以Strm结尾，当 AlistStrm 存储的位置有对应的文件时，*mediasource.Container 会被设置为文件后缀
-				res, err := alistStrmHandler(*mediasource.Path, opt.(string), false)
+				res, err := alistStrmHandler(strmContent, opt.(string), false)
 				if err != nil {
 					logging.Warningf("获取 AlistStrm 重定向 URL 失败: %#v", err)
 					handler.ReverseProxy(ctx.Writer, ctx.Request)

--- a/internal/handler/jellyfin.go
+++ b/internal/handler/jellyfin.go
@@ -201,15 +201,16 @@ func (handler *JellyfinHandler) VideosHandler(ctx *gin.Context) {
 	strmFileType, opt := recgonizeStrmFileType(*item.Path)
 	for _, mediasource := range item.MediaSources {
 		if *mediasource.ID == mediaSourceID { // EmbyServer >= 4.9 返回的ID带有前缀mediasource_
+			strmContent := readStrmContent(*mediasource.Path)
 			switch strmFileType {
 			case constants.HTTPStrm:
 				if *mediasource.Protocol == jellyfin.HTTP {
-					ctx.Redirect(http.StatusFound, handler.httpStrmHandler(*mediasource.Path, ctx.Request.UserAgent()))
+					ctx.Redirect(http.StatusFound, handler.httpStrmHandler(strmContent, ctx.Request.UserAgent()))
 					return
 				}
 
 			case constants.AlistStrm: // 无需判断 *mediasource.Container 是否以Strm结尾，当 AlistStrm 存储的位置有对应的文件时，*mediasource.Container 会被设置为文件后缀
-				res, err := alistStrmHandler(*mediasource.Path, opt.(string), false)
+				res, err := alistStrmHandler(strmContent, opt.(string), false)
 				if err != nil {
 					logging.Warningf("获取 AlistStrm 重定向 URL 失败:%#v", err)
 					handler.ReverseProxy(ctx.Writer, ctx.Request)

--- a/internal/handler/utils.go
+++ b/internal/handler/utils.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -163,4 +164,18 @@ func getFinalURL(client *http.Client, rawURL string, ua string) (string, error) 
 var jsonChainOption = &sjson.Options{
 	Optimistic:     true,
 	ReplaceInPlace: true,
+}
+
+// readStrmContent returns the trimmed content of a .strm file at filePath.
+// If filePath does not end with ".strm", it is returned unchanged.
+func readStrmContent(filePath string) string {
+	if !strings.HasSuffix(strings.ToLower(filePath), ".strm") {
+		return filePath
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		logging.Warningf("读取 strm 文件内容失败: %v", err)
+		return filePath
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/internal/handler/utils_test.go
+++ b/internal/handler/utils_test.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadStrmContent(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("non-strm path returned unchanged", func(t *testing.T) {
+		input := "/data/media/movie.mkv"
+		if got := readStrmContent(input); got != input {
+			t.Errorf("expected %q, got %q", input, got)
+		}
+	})
+
+	t.Run("strm file content returned trimmed", func(t *testing.T) {
+		p := filepath.Join(dir, "movie.strm")
+		if err := os.WriteFile(p, []byte("  /115/movie.mkv\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := readStrmContent(p); got != "/115/movie.mkv" {
+			t.Errorf("expected %q, got %q", "/115/movie.mkv", got)
+		}
+	})
+
+	t.Run("uppercase .STRM extension handled", func(t *testing.T) {
+		p := filepath.Join(dir, "movie.STRM")
+		if err := os.WriteFile(p, []byte("https://example.com/video.mp4"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := readStrmContent(p); got != "https://example.com/video.mp4" {
+			t.Errorf("expected %q, got %q", "https://example.com/video.mp4", got)
+		}
+	})
+
+	t.Run("missing strm file returns path unchanged", func(t *testing.T) {
+		p := filepath.Join(dir, "missing.strm")
+		if got := readStrmContent(p); got != p {
+			t.Errorf("expected %q, got %q", p, got)
+		}
+	})
+}


### PR DESCRIPTION
Jellyfin 10.11.8 changed the Path field to return the local file path instead of the actual content, which broke redirects. Fixed it by reading the .strm file content before passing it to the handlers. Fixes #106.